### PR TITLE
Update Salford template files.

### DIFF
--- a/templates/salford/foot.html
+++ b/templates/salford/foot.html
@@ -1,95 +1,26 @@
-			</div>
 
 		</div>
-
-		<div id="localNavigation">
-
-			<div id="nav">
-				<ul>
-					<li><a href="/"><strong>e-petitions</strong></a></li>
-					<li><a href="/list">View petitions</a></li>
-					<li><a href="/steps">Step-by-step guide</a></li>
-					<li><a href="/faq">Frequently asked questions</a></li>
-					<li><a href="/terms">Terms and conditions</a></li>
-					<li><a href="/privacy">Privacy policy</a></li>
-				</ul>
-			</div>
-
-		</div>
-
-		<div id="siteFunctions">
-
-			<form action="http://www.salford.gov.uk/search.htm" method="get">
-				<fieldset>
-					<legend>Search site</legend>
-					<label for="qt"><strong>Search site</strong></label><br />
-					<input type="hidden" name="col" value="justhtm2" /><input type="text" id="qt" name="qt" size="5" class="searchinput" /><input type="submit" value="GO" id="searchbutton" class="button" />
-				</fieldset>
-			</form>
-
-			<ul id="quickLinks">
-                <li><strong>Quick links</strong></li>
-				<li><a href="http://www.salford.gov.uk/aboutsalford.htm">About Salford</a></li>
-				<li><a href="http://www.salford.gov.uk/complaints.htm"><span class="offscreen">Salford City Council</span> Complaints</a></li>
-				<li><a href="http://www.salford.gov.uk/consultation.htm">Consultations</a></li>
-				<li><a href="http://www.salford.gov.uk/citymayor.htm">City Mayor</a></li>
-				<li><a href="http://www.salford.gov.uk/emergencyplan.htm">Emergencies</a></li>
-				<li><a href="http://www.salford.gov.uk/help.htm" accesskey="6">Help</a></li>
-				<li><a href="https://maps.salford.gov.uk/ExternalGIS/">Interactive maps</a></li>
-				<li><a href="http://www.salford.gov.uk/jobs.htm">Jobs</a></li>
-				<li><a href="http://www.salford.gov.uk/news.htm">News</a></li>
-				<li><a href="http://www.salford.gov.uk/payments.htm">Pay a bill</a></li>
-				<li><a href="http://www.salford.gov.uk/selectservice.htm">Report it!</a></li>
-				<li><a href="http://www.salford.gov.uk/sitemap.htm" accesskey="3">Site map</a></li>
-            </ul>
-
-            <ul id="salford-social">
-                <li><strong>Find us on</strong></li>
-                <li><a href="http://www.facebook.com/SalfordCouncil"><img src="http://www.salford.gov.uk/t/salford-facebook.jpg" alt="Salford City Council on Facebook" /></a></li>
-                <li><a href="http://www.flickr.com/photos/salfordcitycouncil/"><img src="http://www.salford.gov.uk/t/salford-flickr.jpg" alt="Salford City Council on Flickr" /></a></li>
-                <li><a href="http://twitter.com/SalfordCouncil"><img src="http://www.salford.gov.uk/t/salford-twitter.jpg" alt="Salford City Council on Twitter" /></a></li>
-                <li><a href="http://www.youtube.com/user/SalfordCityCouncil"><img src="http://www.salford.gov.uk/t/salford-youtube.jpg" alt="Salford City Council on YouTube" /></a></li>
-                <li><a href="http://www.salford.gov.uk/socialmedia.htm">What are these?</a></li>
-            </ul>
-
-		</div>
-
-	</div>
-
-	<div id="languages" class="clearfix">
-		<ul>
-			<li><a href="http://www.salford.gov.uk/arabic.htm"><img src="http://www.salford.gov.uk/t/index-arabic.gif" alt="Information in Arabic" /></a></li><li><a href="http://www.salford.gov.uk/bengali.htm"><img src="http://www.salford.gov.uk/t/index-bengali.gif" alt="Information in Bengali" /></a></li><li><a href="http://www.salford.gov.uk/cantonese.htm"><img src="http://www.salford.gov.uk/t/index-cantonese.gif" alt="Information in Cantonese" /></a></li><li><a href="http://www.salford.gov.uk/gujarati.htm"><img src="http://www.salford.gov.uk/t/index-gujarati.gif" alt="Information in Gujarati" /></a></li><li><a href="http://www.salford.gov.uk/punjabi.htm"><img src="http://www.salford.gov.uk/t/index-punjabi.gif" alt="Information in Punjabi" /></a></li><li><a href="http://www.salford.gov.uk/urdu.htm"><img src="http://www.salford.gov.uk/t/index-urdu.gif" alt="Information in Urdu" /></a></li>
-		</ul>
-	</div>
-
-	<div id="siteInfo" class="clearfix">
-
-		<div id="copyrightImage"><a href="http://www.salford.gov.uk/copyright.htm"><img src="http://www.salford.gov.uk/t/scc-copyright.gif" alt="Copyright Salford City Council" /></a></div>
-		<div id="rssLink"><a href="http://www.salford.gov.uk/rss-feeds.htm">RSS feeds</a></div>
-
-	</div>
-
-	<div id="information" class="clearfix">
-
-		<div id="scc-address" class="vcard"><strong><span class="fn org">Salford City Council</span></strong>, <span class="adr work"><span class="street-address"><a href="http://www.salford.gov.uk/findus.htm" title="How to find us">Salford Civic Centre</a>, Chorley Road</span>, <span class="locality">Swinton, Salford</span> <span class="postal-code">M27 5AW</span></span> &nbsp; <img src="http://www.salford.gov.uk/t/icon-telephone-small.gif" alt="Telephone" /> <span class="tel work">0161 794 4711</span></div>
-
-		<ul id="information-links">
-			<li class="first"><a href="http://www.salford.gov.uk/accessibility.htm">Accessibility</a></li>
-			<li><a href="http://www.salford.gov.uk/availability.htm">Availability</a></li>
-			<li><a href="http://www.salford.gov.uk/legal.htm">Legal notices</a></li>
-			<li><a href="http://www.salford.gov.uk/localgovgm.htm">Neighbouring councils</a></li>
-			<li><a href="http://www.salford.gov.uk/webstatistics.htm">Website statistics</a></li>
-		</ul>
-
-		<div id="directgov"><a href="http://www.gov.uk/"><img src="http://www.salford.gov.uk/t/govuk.jpg" alt="GOV.UK - the place to find government services and information" /></a></div>
 
 	</div>
 
 </div>
 
-<div id="print">
-	<p>&copy; Copyright Salford City Council</p>
+<div id="footercontainer">
+
+	<div class="contentarea">
+
+		<div class="scc-address vcard"><strong><span class="fn org">Salford City Council</span></strong>, <span class="adr work"><span class="street-address">Salford Civic Centre, Chorley Road</span>, <span class="locality">Swinton, Salford</span>, <span class="postal-code">M27 5AW</span></span></div>
+
+		<div class="govuk"><a href="https://www.gov.uk/"><img src="//services.salford.gov.uk/website/template/images/govuk.png" alt="GOV.UK"></a></div>
+
+	</div>
+
 </div>
+
+<a href="#headercontainer" class="cd-top">Back to top</a>
+
+<script src="//services.salford.gov.uk/website/template/scripts/jquery-1.11.1.min.js"></script>
+<script src="//services.salford.gov.uk/website/template/scripts/sitefunctions.js"></script>
 
 </body>
 </html>

--- a/templates/salford/head.html
+++ b/templates/salford/head.html
@@ -8,7 +8,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <link rel="stylesheet" type="text/css" media="screen" href="//services.salford.gov.uk/website/template/css/reset.css">
 <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:400,700,400italic">
-<link rel="stylesheet" type="text/css" media="screen" href="//services.salford.gov.uk/website/template/css/styles.css">
+<link rel="stylesheet" type="text/css" media="screen" href="//services.salford.gov.uk/website/template/css/epetitions/styles.css">
 <link rel="stylesheet" type="text/css" media="print" href="//services.salford.gov.uk/website/template/css/print.css">
 <link rel="stylesheet" type="text/css" href="http://epetitions.salford.gov.uk/pet.css">
 <link rel="stylesheet" type="text/css" href="http://epetitions.salford.gov.uk/assets/salford/css.css">

--- a/templates/salford/head.html
+++ b/templates/salford/head.html
@@ -1,80 +1,37 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<title>PARAM_TITLE - Salford City Council</title>
-<meta name="author" content="Salford City Council" />
-<meta http-equiv="content-type" content="text/html;charset=iso-8859-1" />
-<meta http-equiv="Content-Style-Type" content="text/css" />
-<style type="text/css">
-#branding {
-background: #000 url(http://www.salford.gov.uk/b/v2-banner39.jpg) no-repeat top right;
-}
-
-#navigation.navigation-council {
-background: #6b5f6d url(http://www.salford.gov.uk/t/council_insalford.gif) no-repeat center right;
-}
-</style>
-<link rel="stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/salford.css" />
-<!--[if IE 8]><link rel="stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/ie7.css" /><![endif]-->
-<!--[if IE 7]><link rel="stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/ie7.css" /><![endif]-->
-<!--[if IE 6]><link rel="stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/ie6.css" /><![endif]-->
-<link rel="stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/default.css" title="default" />
-<link rel="alternate stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/large.css" title="large" />
-<link rel="alternate stylesheet" type="text/css" media="screen" href="http://www.salford.gov.uk/css/extralarge.css" title="extralarge" />
-<link rel="stylesheet" type="text/css" media="print" href="http://www.salford.gov.uk/css/print.css" />
-<link rel="stylesheet" type="text/css" media="handheld" href="http://www.salford.gov.uk/css/mobile.css" />
-<link rel="alternate" href="http://www.salford.gov.uk/press.xml" type="application/rss+xml" title="Recent press releases from Salford City Council" />
-<link rel="alternate" href="http://yourcounciljobs.co.uk/feeds/Jobs_rss.aspx?sAuthority_id=6" type="application/rss+xml" title="Job vacancies from Salford City Council" />
-<link rel="alternate" href="http://services.salford.gov.uk/feeds/events/" type="application/rss+xml" title="What's on in Salford?" />
-<link rel="alternate" href="http://services.salford.gov.uk/feeds/decisions/" type="application/rss+xml" title="Decisions of the council" />
-<script src="http://www.salford.gov.uk/js/jquery-min.js" type="text/javascript"></script>
-<script src="http://www.salford.gov.uk/js/sitefunctions.js" type="text/javascript"></script>
-<script src="/assets/salford/sitefunctions.js" type="text/javascript"></script>
-<link rel="stylesheet" type="text/css" href="/pet.css" />
-<link rel="stylesheet" type="text/css" href="/assets/salford/css.css" />
+<!DOCTYPE html>
+<html lang="en" class="nojs">
+<head runat="server">
+<meta charset="utf-8">
+<title>PARAM_TITLE - e-petitions - Salford City Council</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<link rel="stylesheet" type="text/css" media="screen" href="//services.salford.gov.uk/website/template/css/reset.css">
+<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto:400,700,400italic">
+<link rel="stylesheet" type="text/css" media="screen" href="//services.salford.gov.uk/website/template/css/styles.css">
+<link rel="stylesheet" type="text/css" media="print" href="//services.salford.gov.uk/website/template/css/print.css">
+<link rel="stylesheet" type="text/css" href="http://epetitions.salford.gov.uk/pet.css">
+<link rel="stylesheet" type="text/css" href="http://epetitions.salford.gov.uk/assets/salford/css.css">
 </head>
 
-<body>
+<body class="app content">
 
-<div id="container">
+<div id="contentcontainer" class="default">
 
-	<ul id="accessOptions">
-		<li><a href="#startcontent" accesskey="s"><strong>Skip to content</strong></a></li>
-		<li class="changetext"><a href="http://www.salford.gov.uk/accessibility.htm#textsize"><strong>Change text size</strong></a></li>
-		<li class="cookies"><a href="http://www.salford.gov.uk/cookies.htm"><strong>How we use cookies</strong></a></li>
-	</ul>
+	<div class="contentheader">
 
-	<div id="brandingContainer">
-		<div id="branding">
-		<div id="logo"><h1><a href="http://www.salford.gov.uk/index.htm" title="Salford City Council home page">Salford City Council</a></h1></div>
+		<a id="skip-to-content" href="#contentcontainer">Skip to content</a>
 
-			<ul id="siteServices"><li class="first"><a href="http://www.salford.gov.uk/az.htm" id="azlink"><span>A-Z of services</span></a></li><li><a href="http://www.salford.gov.uk/contacts.htm" id="contactlink"><span>Contact Salford City Council</span></a></li><li class="last"><a href="https://youraccount.salford.gov.uk" id="accountlink"><span>Your account</span></a></li></ul>
-        </div>
+		<div class="brand"><a href="http://www.salford.gov.uk/"><img src="//services.salford.gov.uk/website/template/images/scc.png" alt="Salford City Council"></a></div>
 
-	</div>
-
-	<div id="navigationContainer">
-		<div id="navigation" class="navigation-online">
-			<ul>
-				<li><a href="http://www.salford.gov.uk/index.htm">Home</a></li>
-				<li><a href="http://www.salford.gov.uk/living.htm">Living</a></li>
-				<li><a href="http://www.salford.gov.uk/learning.htm">Learning</a></li>
-				<li><a href="http://www.salford.gov.uk/leisure.htm">Leisure</a></li>
-				<li><a href="http://www.salford.gov.uk/business.htm">Business</a></li>
-				<li><a href="http://www.salford.gov.uk/online.htm">Online services</a></li>
-				<li><a href="http://www.salford.gov.uk/council.htm">Your council</a></li>
-			</ul>
+		<div class="breadcrumb">
+			<strong>You are here:</strong> <a href="http://www.salford.gov.uk/">Home</a> / <a href="http://epetitions.salford.gov.uk/">e-petitions</a> / PARAM_TITLE
 		</div>
+
+		<h1>PARAM_H1</h1>
+
 	</div>
 
-	<div id="contentContainer" class="clearfix">
+	<div class="contentarea">
 
-		<div id="pageContent">
-
-			<div id="breadcrumb"><a href="http://www.salford.gov.uk/">Home</a> &raquo; <a href="http://www.salford.gov.uk/council.htm">Your council</a> &raquo; <a href="http://www.salford.gov.uk/councillors.htm">Council, City Mayor and councillors</a> &raquo; <a href="http://www.salford.gov.uk/petitions.htm">Petitions</a> &raquo; <a href="http://epetitions.salford.gov.uk/">e-petitions</a> &raquo; PARAM_TITLE</div>
-
-			<div id="content">
-
-				<a name="startcontent"></a>
-
-				<h2>PARAM_H1</h2>
+		<div class="pagecontent fullwidth">


### PR DESCRIPTION
The template for Salford City Council websites is being updated as from Monday 4 April. The update in this pull request will bring the epetitions site in line with the new design.