### PR TITLE
Don't fork petitions daemons under systemd

### DIFF
--- a/bin/petemaild
+++ b/bin/petemaild
@@ -35,6 +35,17 @@ use Socket;
 use Data::Dumper;
 
 #
+# Managing Debug mode
+#
+package Debug;
+
+my $enabled = 0;
+sub enabled (;$) {
+    $enabled = $_[0] if defined $_[0];
+    return $enabled;
+}
+
+#
 # Counter to give unique IDs to objects (for logging purposes, mostly).
 #
 package Counter;
@@ -1910,7 +1921,7 @@ sub database_child_process ($) {
         last if ($didclose);
 
         my $fullscan = 0;
-        if (Log::stderronly() || $last_full_scan < time() - 300) {
+        if (Debug::enabled() || $last_full_scan < time() - 300) {
             $fullscan = 1;
             $last_full_scan = time();
             Log::print('debug', "doing full scan of database");
@@ -2519,15 +2530,17 @@ use mySociety::SystemMisc qw(print_log);
 
 my $pidfilepath = mySociety::Config::get('PETEMAILD_PIDFILE', '/var/run/petemaild.pid');
 my $debug = 0;
+my $foreground = 0;
 my $verbose = 0;
 my $help = 0;
 my $noexpire = 0;
 if (!GetOptions(
-        'pidfile=s' =>  \$pidfilepath,
-        debug =>        \$debug,
-        'verbose=i' =>  \$verbose,
-        noexpire =>     \$noexpire,
-        help =>         \$help
+        'pidfile=s' => \$pidfilepath,
+        debug       => \$debug,
+        foreground  => \$foreground,
+        'verbose=i' => \$verbose,
+        noexpire    => \$noexpire,
+        help        => \$help
     )) {
     print_log('err', "bad options; try --help for help");
     exit(1);
@@ -2538,17 +2551,19 @@ if ($help) {
     exit(0);
 }
 
-mySociety::SystemMisc::log_to_stderr(0) if (!$debug);
-# XXX: We call daemon() here AND call it again a few lines later??
-mySociety::SystemMisc::daemon() unless ($debug);
-
 $SIG{TERM} = $SIG{INT} = sub { $foad = 1; };
 
+# Set logging verbosity
+Log::verbose($verbose);
+
+# Only daemonize if `--debug` or `--foreground` aren't given
 if ($debug) {
-    Log::verbose($verbose);
+    Log::stderronly(1);
+    Debug::enabled(1);
+} elsif ($foreground) {
     Log::stderronly(1);
 } else {
-    Log::verbose($verbose);
+    mySociety::SystemMisc::log_to_stderr(0);
     mySociety::SystemMisc::daemon();
 }
 
@@ -2722,8 +2737,13 @@ Display information about using the program.
 
 =item --debug
 
-Don't detach from controlling terminal; log diagnostics to standard error as
-well as the system log.
+Don't detach from controlling terminal; log diagnostics solely to STDERR; 
+set a flag to indicate we're in Debug mode that triggers constant full database
+scans (rather than every five minutes).
+
+=item --foreground
+
+Don't detach from controlling terminal; log diagnostics solely to STDERR.
 
 =item --verbose=n
 

--- a/bin/petsignupd
+++ b/bin/petsignupd
@@ -56,6 +56,17 @@ use mySociety::PIDFile;
 use Petitions;
 use Petitions::RPC;
 
+#
+# Managing Debug mode
+#
+package Debug;
+
+my $enabled = 0;
+sub enabled (;$) {
+    $enabled = $_[0] if defined $_[0];
+    return $enabled;
+}
+
 package Log;
 
 my $verboselevel = 0;
@@ -167,13 +178,15 @@ sub do_pending () {
 my $max_signup_time = mySociety::Config::get('MAX_SIGNUP_TIME', 0.1);
 my $pidfilepath = mySociety::Config::get('PETSIGNUPD_PIDFILE', '/var/run/petsignupd.pid');
 my $debug = 0;
+my $foreground = 0;
 my $verbose = 0;
 my $help = 0;
 if (!GetOptions(
-        'pidfile=s' =>  \$pidfilepath,
-        debug =>        \$debug,
-        'verbose=i' =>      \$verbose,
-        help =>         \$help
+        'pidfile=s' => \$pidfilepath,
+        debug       => \$debug,
+        foreground  => \$foreground,
+        'verbose=i' => \$verbose,
+        help        => \$help
     )) {
     Log::print('err', "bad options; try --help for help");
     exit(1);
@@ -184,14 +197,17 @@ if ($help) {
     exit(0);
 }
 
-mySociety::SystemMisc::log_to_stderr(0) if (!$debug);
-mySociety::SystemMisc::daemon() unless ($debug);
+# Set logging verbosity
+Log::verbose($verbose);
 
+# Only daemonize if `--debug` or `--foreground` aren't given
 if ($debug) {
-    Log::verbose($verbose);
+    Log::stderronly(1);
+    Debug::enabled(1);
+} elsif ($foreground) {
     Log::stderronly(1);
 } else {
-    Log::verbose($verbose);
+    mySociety::SystemMisc::log_to_stderr(0);
     mySociety::SystemMisc::daemon();
 }
 
@@ -337,8 +353,12 @@ Display information about using the program.
 
 =item --debug
 
-Don't detach from controlling terminal; log diagnostics to standard error as
-well as the system log.
+Don't detach from controlling terminal; log diagnostics solely to STDERR and 
+set a flag to indicate we're in Debug mode.
+
+=item --foreground
+
+Don't detach from controlling terminal; log diagnostics solely to STDERR.
 
 =item --verbose=n
 
@@ -358,4 +378,3 @@ Copyright (c) 2006 UK Citizens Online Democracy
 =head1
 
 $Id: petsignupd,v 1.36 2010-03-12 00:06:37 matthew Exp $
-

--- a/conf/petemaild.service.ugly
+++ b/conf/petemaild.service.ugly
@@ -6,10 +6,9 @@ Description=!!(*= $daemon_name *)!!
 After=syslog.target network.target
 
 [Service]
-Type=forking
+Type=simple
 LimitNOFILE=10240
-PIDFile=/data/vhost/!!(*= $vhost *)!!/petemaild.pid
-ExecStart=/data/vhost/!!(*= $vhost *)!!/petitions/bin/petemaild
+ExecStart=/data/vhost/!!(*= $vhost *)!!/petitions/bin/petemaild --foreground
 User=!!(*= $user *)!!
 
 [Install]

--- a/conf/petsignupd.service.ugly
+++ b/conf/petsignupd.service.ugly
@@ -6,9 +6,8 @@ Description=!!(*= $daemon_name *)!!
 After=syslog.target network.target
 
 [Service]
-Type=forking
-PIDFile=/data/vhost/!!(*= $vhost *)!!/petsignupd.pid
-ExecStart=/data/vhost/!!(*= $vhost *)!!/petitions/bin/petsignupd
+Type=simple
+ExecStart=/data/vhost/!!(*= $vhost *)!!/petitions/bin/petsignupd --foreground
 User=!!(*= $user *)!!
 
 [Install]


### PR DESCRIPTION
Under systemd there's no need to fork and in fact the recommended way to run a service is not to do so. Running the petitions daemons using `Type=forking` caused issues due to the way the daemons fork twice.

We could potentially remove the additional fork, but the `--debug` switch for both petemaild and petsignupd avoids forking and simply enables logging to stderr which is useful as this will enable logging to the journal as well as any logfile.

We'd need a new switch if this was used for verbosity, too, but this has its own switch. Perhaps the `--debug` switch would be better renamed `--foreground`.