### PR TITLE
Simplify petemaild

### DIFF
--- a/bin/petemaild
+++ b/bin/petemaild
@@ -3,17 +3,6 @@
 # petemaild:
 # High-performance email sending tool, for sending confirmation and other mails
 # from the petitions site.
-#
-# TODO: test it against a greater variety of real mail servers; occasionally
-# checkpoint retry data so that we can recover after a crash; implement a
-# graceful shutdown procedure; use this program to send announcement messages,
-# as well as confirmations.
-#
-# Copyright (c) 2006 UK Citizens Online Democracy. All rights reserved.
-# Email: chris@mysociety.org; WWW: http://www.mysociety.org/
-#
-
-my $rcsid = ''; $rcsid .= '$Id: petemaild,v 1.156 2010-03-12 19:00:35 matthew Exp $';
 
 # Horrible boilerplate to set up appropriate library paths.
 use FindBin;
@@ -927,27 +916,11 @@ use Carp;
 use Heap::Priority;
 use IO::Select;
 
-use fields qw(messages finished badhosts baddomains r ss lastcheckedqueue
-                noexpire queue debug_messages_to_requeue_local);
+use fields qw(messages finished ss lastcheckedqueue
+                noexpire queue);
 
 # How long a message may stay on the queue before we consider it undeliverable.
 use constant MAX_MESSAGE_AGE => 86400;
-
-# How many simultaneous SMTP connections we make to any given host.
-use constant MAX_HOST_SESSIONS => 5;
-
-# How many messages we attempt to deliver in a single session.
-use constant MAX_PER_SESSION => 20;
-
-# Minimum interval between discovering a host is "bad" and checking again.
-use constant MIN_HOST_BAD_INTERVAL => 15;
-# Maximum interval.
-use constant MAX_HOST_BAD_INTERVAL => 1800;
-
-# Minimum interval between failure to resolve a domain and trying it again.
-use constant MIN_DOMAIN_BAD_INTERVAL => 30;
-# Maximum.
-use constant MAX_DOMAIN_BAD_INTERVAL => 600;
 
 # new [NOEXPIRE]
 # Construct a new queue object. If NOEXPIRE is true, messages older than
@@ -972,15 +945,6 @@ sub new ($;$) {
     # list of completed messages
     $self->{finished} = [ ];
     
-    # records of times when we've seen problems with hosts
-    $self->{badhosts} = { };
-
-    # records of times when we've been unable to resolve domains
-    $self->{baddomains} = { };
-    
-    # DNS client.
-    $self->{r} = new DomainResolver(100);
-
     # SMTP clients.
     $self->{ss} = [ ];
 
@@ -1059,59 +1023,6 @@ sub requeue ($$) {
     }
 }
 
-# thing_bad WHAT THING DB MIN MAX
-#
-sub thing_bad ($$$$$$) {
-    my Queue $self = shift;
-    my ($what, $thing, $db, $minint, $maxint) = @_;
-    if (!exists($db->{$thing})) {
-        return 0;
-    } else {
-        my $l = $db->{$thing};
-Log::print('noise', "$what $thing marked as bad ", join(', ', map { int(time() - $_) } @$l), " s ago");
-        # Only one observation, so try again as soon as a short interval
-        # has passed.
-        if (1 == @$l) {
-            if (time() > $l->[0] + $minint) {
-                return 0;
-            } else {
-                return 1;
-            }
-        }
-
-        # Otherwise check after half as long as the thing has been bad already,
-        # or after $maxint, whichever is sooner.
-        my $lastcheck = $l->[@$l - 1];
-        my $interval = ($lastcheck - $l->[0]) / 2;
-        $interval = $maxint if ($interval > $maxint);
-        if ($lastcheck + $interval > time()) {
-            return 1;
-        } else {
-            return 0;
-        }
-    }
-}
-
-# host_bad ADDRESS
-# Should we assume that the host at ADDRESS is bad, or should it be tried
-# again?
-sub host_bad ($$) {
-    my Queue $self = shift;
-    my $addr = shift;
-    return $self->thing_bad('host', $addr, $self->{badhosts},
-                        MIN_HOST_BAD_INTERVAL, MAX_HOST_BAD_INTERVAL);
-}
-
-# domain_bad DOMAIN
-# Should we assume that resolution of the DOMAIN is failing, or should it be
-# tried again?
-sub domain_bad ($$) {
-    my Queue $self = shift;
-    my $domain = shift;
-    return $self->thing_bad('domain', $domain, $self->{baddomains},
-                        MIN_DOMAIN_BAD_INTERVAL, MAX_DOMAIN_BAD_INTERVAL);
-}
-
 # pre_select RDS WRS
 #
 sub pre_select ($$$) {
@@ -1119,21 +1030,14 @@ sub pre_select ($$$) {
     my IO::Select $rds = shift;
     my IO::Select $wrs = shift;
 
-    # Do pre-select handling for domain resolver and individual SMTP clients.
-    $self->r()->pre_select($rds, $wrs);
+    # Do pre-select handling for individual SMTP clients.
     foreach my $smtp (@{$self->{ss}}) {
         $smtp->pre_select($rds, $wrs);
     }
 
     # Hash of IP addresses to which to send messages to messages to send to
     # them.
-    my %newsessions;
-
-    # Number of sessions already open on each IP address.
-    my %numsessions;
-    foreach my $s (@{$self->ss()}) {
-        ++$numsessions{$s->target()};
-    }
+    my @newsessions;
 
     # Now see whether we should start any more connections.
     my $now = time();
@@ -1141,18 +1045,8 @@ sub pre_select ($$$) {
     $self->{lastcheckedqueue} = $now;
     Log::print('noise', "iterating over queue");
 
-    #
     # The queue allows us to find the nominal retry time for the
-    # next-most-urgent message, and its identity. Unfortunately that's not
-    # enough for us, because when DNS resolution is in progress for a domain,
-    # we need to continue looking for other messages from the queue for later
-    # delivery. For the moment handle this in an ugly way, popping such
-    # messages off the queue and reinserting them after we've gone through the
-    # loop.
-    # 
-
-    my @messages_to_requeue = ( );
-    $self->{debug_messages_to_requeue_local} = \@messages_to_requeue;
+    # next-most-urgent message, and its identity.
     my $level;
     while (defined($level = $self->{queue}->next_level()) && $level <= $now) {
         my $msg = $self->{queue}->pop();
@@ -1185,136 +1079,20 @@ Log::print('debug', "  -> already being delivered");
         }
 Log::print('noise', " ... not presently being delivered");
 
-        my $domain = $msg->domain();
-        if ($self->domain_bad($domain)) {
-Log::print('debug', "  -> but domain $domain is not resolving, holding off");
-            # have another go at the message later
-            push(@messages_to_requeue, [$msg, $now + MIN_DOMAIN_BAD_INTERVAL]);
-            next;
-        }
-
-        # See if we have resolved the domain.
-        my $r = $self->r()->get($domain);
-        if (!$r) {
-Log::print('debug', "  -> domain $domain not resolved, adding to resolver queue");
-            $self->r()->add($domain);
-            push(@messages_to_requeue, [$msg, $level]);   # or $now?
-            next;
-        }
-        # If domain resolution failed, mark the domain as failing and hold off.
-        if ($r->failed()) {
-Log::print('debug', "  -> resolution of $domain failed, holding off");
-            push(@{$self->{baddomains}->{$domain}}, $now);
-            delete($self->r()->results()->{$domain});
-            # have another go at the message later
-            push(@messages_to_requeue, [$msg, $now + MIN_DOMAIN_BAD_INTERVAL]);
-            next;
-        }
-
-Log::print('noise', " ... domain $domain has been resolved");
-        # If the domain is unroutable, then the message should be failed.
-        if ($r->unroutable()) {
-Log::print('debug', "  -> domain $domain is unroutable; failing message");
-            $msg->addevent(Queue::Message::EVENT_PERM_FAILURE);
-            next;
-        }
-Log::print('noise', " ... and is routable");
-        # OK, potentially we want to send this message. See if there's an
-        # appropriate host to which to send it. We must send messages to the
-        # lowest-numbered MX where possible.
-        my $host = undef;
-        # XXX this is suboptimal. Where there are several possible hosts with
-        # equal preference, we should select one for which a new connection is
-        # already being made. Not clear how important this is in practice.
+        # OK, we want to send this message.
 Log::print('debug', "  -> will attempt delivery of ", $msg->id());
-
-        my $max_per_session = MAX_PER_SESSION;
-        my $max_host_sessions = MAX_HOST_SESSIONS;
-        # Some hosts are more... paranoid than others. Yahoo! publish, for
-        # example, the very helpful: "You may open concurrent connections from
-        # the same server to facilitate efficient transmission of your messages.
-        # However, while we do not publish specific guidelines for the numbers
-        # of connections you can concurrently use" - so err on the side of 1.
-        # And whilst they say "Yahoo! Mail accepts a maximum of 20 messages per
-        # SMTP connection." it used to be 5 and they're very easily tripped, so...
-        if ( $domain =~ /yahoo|btinternet|hotmail|live|msn|talktalk|sky|ntlworld|virginmedia/i ) {
-            $max_per_session = 4;
-            $max_host_sessions = 1;
-        }
-
-        # Iterate over MXs in order.
-        foreach my $mx (@{$r->mx()}) {
-            my $name = $mx->exchange();
-            foreach my $a (@{$r->a($name)}) {
-                my $h = $a->address();
-                $numsessions{$h} ||= 0;
-Log::print('debug', "      host is bad") if $self->host_bad($a->address);
-Log::print('debug', "      already have @{[$numsessions{$h}]} sessions to host") if $numsessions{$h} >= $max_host_sessions;
-Log::print('debug', "      already queued up a full session for host") if exists($newsessions{$h}) && @{$newsessions{$h}} >= $max_per_session;
-
-                        # conditions:
-                        # host is not bad
-                if (!$self->host_bad($a->address())
-                        # and we don't have too many outstanding sessions to
-                        # that host
-                    && $numsessions{$h} < $max_host_sessions
-                        # and we haven't already queued up too many messages
-                        # for that host
-                    && (!exists($newsessions{$h})
-                        || @{$newsessions{$h}} < $max_per_session)) {
-                    ++$numsessions{$h} if (!exists($newsessions{$h}));
-                    $host = $h;
-                    last;
-                }
-            }
-            last if ($host);
-        }
-
-        # We've found a possible host.
-        if (defined($host)) {
-            $newsessions{$host} ||= [ ];
-            push(@{$newsessions{$host}}, $msg);
-
-            if (@{$newsessions{$host}} == $max_per_session) {
-                my $s = new Sender($host, $newsessions{$host});
-                Log::printf('info',
-                            'created sender S%s for %s to send %d messages',
-                            $s->id(),
-                            $host,
-                            scalar(@{$newsessions{$host}}));
-                push(@{$self->{ss}}, $s);
-                delete($newsessions{$host});
-                ++$numsessions{$host};
-                # at this point the message is off the queue completely; it
-                # may be requeued when its ->addevent method is called by
-                # the sender
-            }
-        } else {
-            # XXX FAI A resolver sometimes gets into this state, and there is
-            # then no way or it to get out again.
-            Log::print('debug', "     ... but cannot find any valid host");
-            $self->requeue($msg, 5); # XXX
-        }
+        push(@newsessions, $msg);
     }
     Log::print('noise', 'finished iterating over queue');
 
-    # now put any relevant messages back on the queue
-    foreach (@messages_to_requeue) {
-        my ($msg, $level) = @$_;
-        $self->{queue}->add($msg, $level);
-        $msg->{priority} = $level;
-    }
-    @messages_to_requeue = ( );
-
-    # Create new sessions for each host.
-    foreach my $host (keys %newsessions) {
-        my $s = new Sender($host, $newsessions{$host});
-        Log::printf('info', 'created sender S%s for %s to send %d messages',
-                        $s->id(),
-                        $host,
-                        scalar(@{$newsessions{$host}}));
-        push(@{$self->{ss}}, $s);
-    }
+    # Create new session
+    my $host = '127.0.0.1';
+    my $s = new Sender($host, \@newsessions);
+    Log::printf('info', 'created sender S%s for %s to send %d messages',
+                    $s->id(),
+                    $host,
+                    scalar(@newsessions));
+    push(@{$self->{ss}}, $s);
 }
 
 # post_select RDS WRS
@@ -1323,7 +1101,6 @@ sub post_select ($$$) {
     my Queue $self = shift;
     my ($rds, $wrs) = @_;
 
-    $self->r()->post_select($rds, $wrs);
     # Free sender objects which have finished.
     my @ss;
     foreach my $smtp (@{$self->{ss}}) {
@@ -1343,12 +1120,6 @@ sub post_select ($$$) {
         } else {
             push(@ss, $smtp);
         }
-
-        if ($bad) {
-            Log::print('info', "recording host ", $smtp->target(), " as bad: $bad");
-            $self->{badhosts}->{$smtp->target()} ||= [ ];
-            push(@{$self->{badhosts}->{$smtp->target()}}, time());
-        }
     }
     $self->{ss} = \@ss;
 
@@ -1367,14 +1138,10 @@ sub get_finished ($) {
     return shift(@{$self->{finished}});
 }
 
-# accessors
-foreach (qw(r ss)) {
-    eval <<EOF;
-sub $_ (\$) {
-    my Queue \$self = shift;
-    return \$self->{$_};
-}
-EOF
+# accessor
+sub ss ($) {
+    my Queue $self = shift;
+    return $self->{ss};
 }
 
 #
@@ -2006,517 +1773,6 @@ sub database_child_process ($) {
 }
 
 #
-# A single domain-resolution task.
-#
-package DomainResolver::Task;
-
-use Carp;
-use Net::DNS ();
-use Regexp::Common;
-use Sys::Syslog;
-
-use fields qw(id starttime r domain state sockets mx a);
-
-# State machine: we resolve the domain first as an MX record, and, once we have
-# the results of that resolution, continue to resolve the individual A records
-# (unless the MXs all point to IP addresses, in which case we regard it as
-# complete).
-#
-# We may see either temporary (SERVFAIL) or permanent (NXDOMAIN) errors from
-# DNS queries. If we see NXDOMAIN for the domain both as MX and A record then
-# the domain is unroutable and we can fail email addressed to it; other
-# resolution failures must be treated as temporary.
-
-            # resolving MX records
-use constant STATE_MX   => 0;
-            # resolving A records
-use constant STATE_A    => 1;
-            # finished all resolution
-use constant STATE_DONE => 2;
-            # something broke before the query was complete
-use constant STATE_BAD  => 3;
-
-our @statename = qw(STATE_MX STATE_A STATE_DONE STATE_BAD);
-
-use constant MX_PREF_FAKE => -1;
-
-# Longest time in seconds we cache a negative result for.
-use constant MAX_NEGATIVE_CACHE => 10;
-
-# new RESOLVER DOMAIN
-# Return a new task for resolving DOMAIN using RESOLVER.
-sub new ($$$) {
-    my DomainResolver::Task $self = shift;
-    my Net::DNS::Resolver $r = shift;
-    my $domain = shift;
-    $self = fields::new($self)
-        unless (ref($self));
-
-    $self->{id} = Counter::value();
-    $self->{starttime} = time();
-    $self->{r} = $r;
-    $self->{domain} = $domain;
-    $self->{state} = STATE_MX;
-    $self->{sockets} = { };
-    $self->{mx} = [ ];
-    $self->{a} = { };
-
-    $self->log('debug', "resolving $domain");
-
-    # Start the first query.
-    my $s = $r->bgsend($domain, 'MX');
-    $self->{sockets}->{$s} = $s;
-
-    return $self;
-}
-
-# log PRIORITY TEXT [...]
-# Log a message about this resolution task.
-sub log ($$@) {
-    my DomainResolver::Task $self = shift;
-    my $prio = shift;
-    unshift(@_, "R$self->{id}($self->{domain}): ");
-    Log::print($prio, @_);
-}
-
-# state [STATE]
-# Get/set state.
-sub state ($;$) {
-    my DomainResolver::Task $self = shift;
-    if (@_) {
-        $self->{state} = $_[0];
-        $self->log('debug', "-> $statename[$_[0]]");
-        $self->log('debug', "completed") if ($_[0] == STATE_DONE);
-    }
-    return $self->{state};
-}
-
-# pre_select RDS WRS
-#
-sub pre_select ($$$) {
-    my DomainResolver::Task $self = shift;
-    return if ($self->state() != STATE_MX && $self->state() != STATE_A);
-    my IO::Select $rds = shift;
-    my IO::Select $wrs = shift;
-    foreach my $s (values(%{$self->{sockets}})) {
-        $rds->add($s);
-    }
-}
-
-# is_valid_domain DOMAIN
-# Is DOMAIN a valid domain name?
-sub is_valid_domain ($) {
-    my $domain = lc(shift);
-    # AAAAARGH. Would just use $RE{net}{domain} from Regexp::Common, except for
-    # the fact that its idea of what constitutes a domain name comes from
-    # RFC1035, and therefore dates back to 1987 when it wasn't valid to have
-    # a number at the beginning of a domain name. "The 1980s called, they want
-    # their 3Com back!"
-    my $ld = '[0-9a-z]';
-    my $ldh = '[0-9a-z-]';
-    return ($domain =~ /^$ld(|$ldh{0,61}$ld)(\.$ld(|$ldh{0,61}$ld))*$/);
-}
-
-# post_select RDS WRS
-# Post-select processing. RDS and WRS are references to hashes whose keys are
-# handles which are, respectively, available for reading and for writing.
-sub post_select ($$) {
-    my DomainResolver::Task $self = shift;
-    my ($rds, $wrs) = @_;
-    foreach my $s (values(%{$self->{sockets}})) {
-        if ($rds->{$s}) {
-            my $result = $self->{r}->bgread($s);
-            if (!defined($result)) {
-                $self->log('warning', "failed; system error $!");
-                $self->state(STATE_BAD);
-                return;
-            }
-            delete($self->{sockets}->{$s});
-            undef $s;
-            if ($self->state() == STATE_MX) {
-                #
-                # Response to query for MX records for the domain.
-                # 
-
-                my $q = ($result->question())[0]->qname();
-                
-                if ($result->header()->rcode() eq 'SERVFAIL') {
-                    # Transient error attempting to resolve the domain.
-                    $self->{mx} = undef;
-                    $self->log('warning', "temporary failure resolving MX record for '$q'");
-                    $self->state(STATE_BAD);
-                    return;
-                } elsif ($result->header()->rcode() eq 'NXDOMAIN') {
-                    # There is no such domain, so the mail would be unroutable.
-                    $self->{mx} = undef;
-                    $self->log('debug', 'no such domain (unroutable)');
-                    $self->state(STATE_DONE);
-                    return;
-                }
-
-                # The answers we get here will be either MXs or perhaps a CNAME
-                # (we shouldn't see a CNAME and an MX -- Google for the
-                # notorious BIND error, "CNAME and other data"). Be a little
-                # more liberal: extract any MXs and sort them by preference.
-                $self->{mx} = [
-                        sort { $a->preference() <=> $b->preference() }
-                            grep { $_->type() eq 'MX' } $result->answer()
-                    ];
-                
-                if (@{$self->{mx}}) {
-                    # Have some MXs.
-                    $self->log('debug', "MXs are: ",
-                                join(', ', map { $_->preference() . " "
-                                                    . $_->exchange() }
-                                    @{$self->{mx}}));
-                } else {
-                    # No MXs. To keep the data structures simpler, fake up an
-                    # MX record to the domain itself, which we will then
-                    # resolve as an address.
-                    $self->log('debug', "no MXs; will route to A record");
-                    $self->{mx} = [
-                            new Net::DNS::RR(
-                                type => 'MX',
-                                name => $self->domain(),
-                                exchange => $self->domain,
-                                preference => MX_PREF_FAKE,
-                                ttl => 86400
-                            )
-                        ];
-                }
-
-                # Now do all the A queries.
-                my $nq = 0;
-                my $nip = 0;
-                my %have;
-                my %cull_mx = ( );
-                foreach my $mx (@{$self->{mx}}) {
-                    my $host = $mx->exchange();
-                    if (exists($have{$host})) {
-                        $self->log('warning', "duplicate MX $host")
-                            if ($have{$host} == 1);
-                        ++$have{$host};
-                        next;
-                    }
-                    $have{$host} = 1;
-                    # Some sites have MX records pointing to IP addresses.
-                    # This is wrong but not uncommon, so accept it.
-                    if ($host =~ /^$RE{net}{IPv4}$/) {
-                        $self->{a}->{$host} = [
-                                new Net::DNS::RR(
-                                        name => $host,
-                                        type => 'A',
-                                        address => $host
-                                    )
-                            ];
-                        ++$nip
-                    } elsif (!is_valid_domain($host)) {
-                        $self->log('warning', "exchange $host is not a valid domain name; ignoring it");
-                        $cull_mx{$host} = 1;
-                    } else {
-                        my $s = $self->{r}->bgsend($mx->exchange(), 'A');
-                        $self->{sockets}->{$s} = $s;
-                        ++$nq;
-                    }
-                }
-
-                # If any of the MXs were bogus, cull them here.
-                foreach my $q (keys(%cull_mx)) {
-                    @{$self->{mx}} = grep { $_->exchange() ne $q } @{$self->{mx}};
-                }
-
-                if ($nq) {
-                    $self->state(STATE_A);
-                } elsif ($nip) {
-                    $self->log('debug', 'all MXs point to IP addresses');
-                    $self->state(STATE_DONE);
-                } else {
-                    $self->log('warning', 'no valid MXs');
-                    $self->{mx} = undef;
-                    $self->state(STATE_DONE);
-                }
-            } elsif ($self->state() == STATE_A) {
-                # 
-                # Response to query for A records for mail exchanges.
-                #
-
-                my $q = ($result->question())[0]->qname();
-
-                if ($result->header()->rcode() eq 'SERVFAIL') {
-                    # Transient error attempting to resolve the domain - ignore this particular MX for now.
-                    $self->log('warning', "temporary failure resolving A record for '$q'");
-                    @{$self->{mx}} = grep { $_->exchange() ne $q } @{$self->{mx}};
-                    delete $self->{a}->{$q};
-                    $self->{mx} = undef if (!@{$self->{mx}});
-                    $self->state(STATE_BAD) if (!keys(%{$self->{sockets}}) && !$self->{mx});
-                    $self->state(STATE_DONE) if (!keys(%{$self->{sockets}}) && $self->{mx});
-                    return;
-                } elsif ($result->header()->rcode() eq 'NXDOMAIN') {
-                    # This A record does not exist.
-                    $self->log('warning', "exchange $q does not exist");
-                    @{$self->{mx}} = grep { $_->exchange() ne $q } @{$self->{mx}};
-                    delete $self->{a}->{$q};
-                    $self->{mx} = undef if (!@{$self->{mx}});
-                        # XXX Is this correct? If a domain has a number of MXs,
-                        # all of which have exchanges which are NXDOMAIN,
-                        # should the domain really be regarded as unroutable?
-                    $self->state(STATE_DONE) if (!keys(%{$self->{sockets}}));
-                    return;
-                }
-
-                # It's possible that one of these domains could be a CNAME
-                # which doesn't point to any A records, so check for this
-                # case.
-                my @a = grep { $_->type eq 'A' } $result->answer();
-
-                if (@a) {
-                    # Found some addresses.
-                    $self->{a}->{$q} = \@a;
-                    $self->log('debug', "MX $q has A records: ",
-                                join(', ', map { $_->address() } @a));
-                } else {
-                    # There are no A records for that domain.
-                    $self->log('warning', "MX $q has no address; dropping it");
-                    @{$self->{mx}} = grep { $_->exchange() ne $q } @{$self->{mx}};
-                    $self->log('warning', "now \$self->{mx} = [qw(" . join(' ', @{$self->{mx}}) . ")]");
-                    delete $self->{a}->{$q};
-#                    @{$self->{a}} = grep { $_ ne $q } @{$self->{a}};
-
-                    # If that dropped our last possible host, then the domain
-                    # is unroutable; mark it as such.
-                    $self->{mx} = undef if (!@{$self->{mx}});
-                }
-
-                # If that was the last query in progress, we're done.
-                $self->state(STATE_DONE) if (!keys(%{$self->{sockets}}));
-            } else {
-                croak "bad state " . $self->state() . " in post_select";
-            }
-        }
-    }
-}
-
-#
-# Accessors
-#
-
-sub domain ($) {
-    my DomainResolver::Task $self = shift;
-    return $self->{domain};
-}
-
-sub starttime ($) {
-    my DomainResolver::Task $self = shift;
-    return $self->{starttime};
-}
-
-# done
-# Return true if resolution was completed.
-sub done ($) {
-    my DomainResolver::Task $self = shift;
-    return $self->{state} == STATE_DONE;
-}
-
-# failed
-# Return true if resolution failed.
-sub failed ($) {
-    my DomainResolver::Task $self = shift;
-    return $self->{state} == STATE_BAD;
-}
-
-# unroutable
-# Return true if the domain is unroutable.
-sub unroutable ($) {
-    my DomainResolver::Task $self = shift;
-    return !defined($self->{mx});
-}
-
-# mx
-# Returns a reference to a list of the MXs for this domain, as Net::DNS::RR::MX
-# objects. Returns undef for unroutable domains. It is an error to call this
-# method unless the request is complete.
-sub mx ($) {
-    my DomainResolver::Task $self = shift;
-    croak "can't call ->mx() outside STATE_DONE" unless ($self->done());
-    return $self->{mx};
-}
-
-# a HOST
-# Returns a reference to a list of the addresses of HOST. HOST must be one of
-# the mail exchanges indicated in the domain's MX records. It is an error to
-# call this method unless the request is complete.
-sub a ($$) {
-    my DomainResolver::Task $self = shift;
-    croak "can't call ->a(HOST) outside STATE_DONE" unless ($self->done());
-    my $host = shift;
-    croak "can't use ->a(HOST) to resolve $host, which is not an MX for $self->{domain}"
-        unless (exists($self->{a}->{$host}));
-    return $self->{a}->{$host};
-}
-
-# valid
-# Return true if the cached result is still valid, or false otherwise. This
-# uses the minimum of the RTTs in any of the returned RRs.
-sub valid ($) {
-    my DomainResolver::Task $self = shift;
-    croak "can't call ->valid() outside STATE_DONE" unless ($self->done());
-    # Cache negative responses for a fixed time.
-    if (!defined($self->mx())) {
-        if ($self->starttime() + MAX_NEGATIVE_CACHE < time()) {
-            return 0;
-        }
-    } else {
-        foreach my $mx (@{$self->mx()}) {
-            my $ttl = $mx->ttl();
-            $ttl = 10 unless $ttl;
-            return 0 if ($self->starttime() + $ttl < time());
-            foreach my $a (@{$self->a($mx->exchange())}) {
-                $ttl = $a->ttl();
-                $ttl = 10 unless $ttl;
-                return 0 if ($self->starttime() + $ttl < time());
-            }
-        }
-    }
-    return 1;
-}
-
-#
-# The domain resolver is responsible for resolving right-hand-sides of email
-# addresses to identify the servers to which mail should be sent.
-#
-package DomainResolver;
-
-use Carp;
-use Net::DNS;
-
-use fields qw(r maxrequests queue state results);
-
-# new NUM
-# Create a new DomainResolver, with a limit of NUM simultaneous outstanding
-# requests. (Each consumes a small number of file descriptors.)
-sub new ($$) {
-    my DomainResolver $self = shift;
-    my $max = shift;
-    $self = fields::new($self)
-        unless (ref($self));
-
-    croak "NUM must be a positive integer" unless ($max =~ /^[1-9]\d*$/);
-
-    $self->{r} = new Net::DNS::Resolver()
-        or croak "cannot create Net::DNS::Resolver; system error: $!";
-    $self->{maxrequests} = $max;
-    
-    # Queue of domains to resolve.
-    $self->{queue} = [ ];
-    # Hash of domains to resolution tasks.
-    $self->{state} = { };
-    # Hash of domains to resolution results.
-    $self->{results} = { };
-        
-    return $self;
-}
-
-# Accessors
-foreach (qw(r maxrequests state results)) {
-    eval <<EOF;
-sub $_ (\$) {
-    my DomainResolver \$self = shift;
-    return \$self->{$_};
-}
-EOF
-}
-
-# add DOMAIN
-# Add DOMAIN to the queue of domains to resolve. This is a no-op if DOMAIN is
-# already in the queue, or if we have a cached valid record for DOMAIN.
-sub add ($$) {
-    my DomainResolver $self = shift;
-    my $domain = shift;
-    my $r = $self->results()->{$domain};
-    if ($r && $r->failed()) {
-        delete($self->results()->{$domain});
-        $r = undef;
-    }
-    push(@{$self->{queue}}, $domain)
-        unless (exists($self->state()->{$domain})
-                || $r);
-}
-
-# getqueue
-# Get a domain to resolve off the queue.
-sub getqueue ($) {
-    my DomainResolver $self = shift;
-    return shift(@{$self->{queue}});
-}
-
-# get DOMAIN
-# Return information about the mailservers for DOMAIN. If they have not yet
-# been resolved or if the cached result is not valid, return undef; otherwise
-# return the task object generated. It is possible for the returned object to
-# indicate that domain resolution failed, in which case it may be retried.
-sub get ($$) {
-    my DomainResolver $self = shift;
-    my $domain = shift;
-    if (!exists($self->results()->{$domain})) {
-        return undef;   # add to queue?
-    } elsif (!$self->results()->{$domain}->failed()
-                && !$self->results()->{$domain}->valid()) {
-        delete($self->results()->{$domain});
-        return undef;
-    } else {
-        return $self->results()->{$domain};
-    }
-}
-
-# queuelength
-# Return the current length of the queue.
-sub queuelength ($) {
-    my DomainResolver $self = shift;
-    return scalar(@{$self->{queue}});
-}
-
-# pre_select RDS WRS
-#
-sub pre_select ($$$) {
-    my DomainResolver $self = shift;
-    my IO::Select $rds = shift;
-    my IO::Select $wrs = shift;
-
-    # Add existing tasks to the masks.
-    foreach my $t (values(%{$self->state()})) {
-        $t->pre_select($rds, $wrs);
-    }
-
-    # Consider starting some new ones.
-    while (scalar(keys(%{$self->state()})) < $self->maxrequests()
-            && @{$self->{queue}}) {
-        my $domain = $self->getqueue();
-        next if (exists($self->state()->{$domain})
-                 || defined($self->get($domain)));
-        my $t = new DomainResolver::Task($self->r(), $domain);
-        $t->pre_select($rds, $wrs);
-        $self->state()->{$domain} = $t;
-    }
-}
-
-# post_select RDS WRS
-# Call after select. RDS and WRS are hashes containing a key for each handle
-# which was marked readable or writable respectively.
-sub post_select ($$) {
-    my DomainResolver $self = shift;
-    my ($rds, $wrs) = @_;
-    
-    foreach my $t (values(%{$self->state()})) {
-        $t->post_select($rds, $wrs);
-        if ($t->done() || $t->failed()) {
-            # save results, whether negative or positive
-            $self->results()->{$t->domain()} = $t;
-            delete($self->state()->{$t->domain()});
-        }
-    }
-}
-
-#
 # Main program.
 #
 package main;
@@ -2592,29 +1848,6 @@ $SIG{USR2} = sub {
         print FH "\nQueue info:\n";
         print FH "messages count: " . scalar(keys(%{$Q->{messages}})) . "\n";
         print FH "finished count: " . scalar(@{$Q->{finished}}) . "\n";
-        print FH "badhosts count: " . scalar(keys(%{$Q->{badhosts}})) . ", they are:\n";
-        foreach my $badhost_key (keys(%{$Q->{badhosts}})) {
-            my $l = $Q->{badhosts}->{$badhost_key};
-            print FH "\t$badhost_key times: ";
-            foreach my $attempt (@$l) {
-                print FH "$attempt ";
-            }
-            print FH "\n";
-        }
-        print FH "baddomains count: " . scalar(keys(%{$Q->{baddomains}})) . "\n";
-        foreach my $baddomain_key (keys(%{$Q->{baddomains}})) {
-            my $l = $Q->{baddomains}->{$baddomain_key};
-            print FH "\t$baddomain_key times: ";
-            foreach my $attempt (@$l) {
-                print FH "$attempt ";
-            }
-            print FH "\n";
-        }
-        print FH "domain resolver\n";
-        print FH "\tmaxrequests: " . $Q->{r}->{maxrequests} . "\n";
-        print FH "\tqueue count: " . scalar(@{$Q->{r}->{queue}}) . "\n";
-        print FH "\tstate count: " . scalar(keys(%{$Q->{r}->{state}})) . "\n";
-        print FH "\tresults count: " . scalar(keys(%{$Q->{r}->{results}})) . "\n";
         print FH "smtp clients count: " . scalar(@{$Q->{ss}}) . ", they are:\n";
         my $total_messages_in_smtp = 0;
         foreach my $smtp_client (@{$Q->{ss}}) {
@@ -2647,7 +1880,6 @@ $SIG{USR2} = sub {
         print FH "lastcheckedqueue: " . $Q->{lastcheckedqueue} . "\n";
         print FH "noexpire: " . $Q->{noexpire} . "\n";
         print FH "queue count: " . $Q->{queue}->count . "\n";
-        print FH "messages to requeue: " . scalar(@{$Q->{debug_messages_to_requeue_local}}) . "\n";
         print FH "\n";
 
         # Hunt for missing messages, which have dropped off queue by surprise
@@ -2662,9 +1894,6 @@ $SIG{USR2} = sub {
             foreach my $message (@{$smtp_client->{messages}}) {
                 $all_messages{$message->id()} = $message; 
             }
-        }
-        foreach my $message (@{$Q->{debug_messages_to_requeue_local}}) {
-            $all_messages{$message->id()} = $message;
         }
         # XXX should add @finished here, but things don't last there long so doesn't matter much
         # (the finished count being nearly always zero shows that is the case)

--- a/bin/petemaild
+++ b/bin/petemaild
@@ -34,20 +34,6 @@ sub enabled (;$) {
     return $enabled;
 }
 
-#
-# Counter to give unique IDs to objects (for logging purposes, mostly).
-#
-package Counter;
-
-my $starttime = time();
-my $id = 0;
-
-# value
-# Return the current value of the counter and increment it.
-sub value () {
-    return sprintf('%08x', $starttime ^ ($id++));
-}
-
 package Log;
 
 use mySociety::SystemMisc qw(open_log print_log);
@@ -122,11 +108,10 @@ sub printf ($$;@) {
 package Queue::Message;
 
 use Carp;
-use Scalar::Util qw(weaken);
 use Time::HiRes qw(time);
 
-use fields qw(id state sender recipient domain text events owner starttime
-                createdtime nattempts lastattempt queue priority);
+use fields qw(id state sender recipient domain text events starttime
+                createdtime queue priority);
 
             # message is yet to be sent successfully
 use constant STATE_PENDING =>       0;
@@ -163,7 +148,6 @@ sub new ($$$$$$) {
     $self->{recipient} = $recipient;
     $self->{text} = $_[3];  # XXX ref?
     $self->{events} = [ ];
-    $self->{owner} = undef;
     $self->{queue} = $queue;
 
     $self->{starttime} = time();
@@ -173,8 +157,6 @@ sub new ($$$$$$) {
     $domain =~ s/.*@//;
     $self->{domain} = lc($domain);
 
-    $self->{nattempts} = 0;
-    
     $self->log('info', "from <$sender> to <$recipient> length ", length($_[3]));
         # XXX would be nice to log the Message-ID: here
     $self->addevent(EVENT_CREATED);
@@ -195,14 +177,9 @@ sub log ($$@) {
 # Record the given EVENT on the message.
 sub addevent ($$;$) {
     my Queue::Message $self = shift;
-    my ($event, $ipaddr) = @_;
+    my ($event) = @_;
     my $t = time();
-    push(@{$self->{events}}, [$event, $t, $ipaddr]);
-
-    if ($event == EVENT_TEMP_FAILURE || $event == EVENT_PERM_FAILURE) {
-        ++$self->{nattempts};
-        $self->{lastattempt} = $t;
-    }
+    push(@{$self->{events}}, [$event, $t]);
 
     if ($event == EVENT_PERM_FAILURE) {
         $self->log('warning', 'delivery failed permanently');
@@ -226,683 +203,14 @@ sub state ($;$) {
     return $self->{state};
 }
 
-# owner [OWNER]
-# Get or set the current owner of this message.
-sub owner ($;$) {
-    my Queue::Message $self = shift;
-    if (@_) {
-        my $owner = shift;
-        croak "OWNER must be undef or a reference" unless (!defined($owner) || ref($owner));
-        # Make this a weak ref so that ideally a bug in relinquishing ownership
-        # won't result in messages being stuck on the queue.
-        weaken($owner) if (ref($owner));
-        $self->{owner} = $owner;
-    }
-    return $self->{owner};
-}
-
 # Accessors.
-foreach (qw(id sender recipient domain text events starttime createdtime
-            nattempts lastattempt)) {
+foreach (qw(id sender recipient domain text events starttime createdtime)) {
     eval <<EOF;
 sub $_ (\$) {
     my Queue::Message \$self = shift;
     return \$self->{$_};
 }
 EOF
-}
-
-#
-# Sender (SMTP session) objects connect to servers and send email.
-# 
-package Sender;
-
-use Carp;
-use IO::Socket;
-use Regexp::Common;
-use Time::HiRes qw(time);
-
-use fields qw(id target messages message state s sendbuf recvbuf
-                lastactivity error delivered tempfailed permfailed);
-
-#
-# State machine. Basically this is very simple; we change into a new state
-# whenever we transmit an SMTP command, and the current state influences the
-# effect of parsing the response to that command. The other states deal with
-# the opening and closing of connections, and transport-level errors.
-#
-
-            # socket created, not connected yet
-use constant STATE_CONNECT =>       0;
-            # waiting for banner
-use constant STATE_BANNER =>        1;
-            # sent HELO, awaiting response
-use constant STATE_HELO =>          2;
-            # sent MAIL FROM, awaiting response
-use constant STATE_MAIL_FROM =>     3;
-            # sent RCPT TO, awaiting response
-use constant STATE_RCPT_TO =>       4;
-            # sent DATA command, awaiting response
-use constant STATE_DATA =>          5;
-            # sending message
-use constant STATE_MESSAGE =>       6;
-            # sent QUIT, awaiting response
-use constant STATE_QUIT =>          7;
-            # received final response from server, awaiting disconnect
-use constant STATE_EOF =>           8;
-            # sent RSET, awaiting response
-use constant STATE_RSET =>          9;
-            # all done without error
-use constant STATE_DONE =>         10;
-            # transport-level error
-use constant STATE_BAD =>          11;
-
-our @statename = qw(STATE_CONNECT STATE_BANNER STATE_HELO STATE_MAIL_FROM
-                    STATE_RCPT_TO STATE_DATA STATE_MESSAGE STATE_QUIT
-                    STATE_EOF STATE_RSET STATE_DONE STATE_BAD);
-
-# We maintain an activity timer which is updated whenever we receive an SMTP
-# response. Timeouts are detected in pre_select and result in an abort.
-use constant TIMEOUT => 90;
-
-# new TARGET MESSAGES
-# TARGET is the host to which we connect; MESSAGES is a reference to a list of
-# message we attempt to send.
-sub new ($$$) {
-    my Sender $self = shift;
-    my $target = shift;
-    my $msgs = shift;
-    croak "TARGET must be an IP address" unless ($target =~ /^$RE{net}{IPv4}$/);
-
-    croak "MESSAGES must be a reference to a list of unowned Queue::Message"
-        unless (ref($msgs) eq 'ARRAY'
-                && !(grep { ref($_) ne 'Queue::Message' } @$msgs)
-                && !(grep { defined($_->owner()) } @$msgs));
-    $self = fields::new($self)
-        unless (ref($self));
-
-    # A value to uniquely identify this connection, for logging.
-    $self->{id} = Counter::value();
-    foreach (@$msgs) {
-        $_->owner($self);
-    }
-    $self->{messages} = $msgs;
-    $self->{message} = undef;
-    $self->{target} = $target;
-    $self->{error} = undef;
-    my $source_ip = mySociety::Config::get('EMAIL_SOURCE_IP', '0.0.0.0');
-    $self->{s} = new IO::Socket::INET(
-                            LocalAddr => $source_ip,
-                            PeerAddr => $target,
-                            PeerPort => 25,
-                            Type => SOCK_STREAM,
-                            Proto => 'tcp',
-                            Blocking => 0
-                        );
-    if (!$self->{s}) {
-        $self->{error} = "socket: $!";
-        $self->state(STATE_BAD); # call via function, so messages temp failed
-        return $self;
-    }
-
-#    binmode($self->{s}, ':bytes');  # why take chances?
-    $self->{state} = STATE_CONNECT;
-    my $s = "";
-    $self->{sendbuf} = \$s;
-    my $r = "";
-    $self->{recvbuf} = \$r;
-
-    $self->{lastactivity} = time();
-
-    $self->log('noise', "delivering ", scalar(@$msgs), " messages to $self->{target}");
-
-    return $self;
-}
-
-# log PRIORITY MESSAGE [...]
-# Write information relating to this sender to the logfile. Log lines will be
-# preceded with "S" and a unique ID for this connection.
-sub log ($$@) {
-    my Sender $self = shift;
-    my $prio = shift;
-    my $tag;
-    if ($self->{message}) {
-        $tag = sprintf('S%s(%s, M%s): ', $self->id(), $self->target(), $self->{message}->id());
-    } else {
-        $tag = sprintf('S%s(%s): ', $self->id(), $self->target());
-    }
-    
-    unshift(@_, $tag);
-    Log::print($prio, @_);
-}
-
-# state [STATE]
-# Get/set state.
-sub state ($;$) {
-    my Sender $self = shift;
-    if (@_) {
-        $self->{state} = $_[0];
-        $self->log('noise', "-> $statename[$_[0]]");
-
-        # Once we're finished, relinquish ownership of the messages, regarding
-        # each as having undergone a temporary failure.
-        if ($_[0] == STATE_DONE || $_[0] == STATE_BAD) {
-            $self->tempfail(); # fail message which was being sent, if any
-            foreach (@{$self->{messages}}) {
-                $_->owner(undef);
-                $_->addevent(Queue::Message::EVENT_TEMP_FAILURE,
-                                $self->{target});
-                ++$self->{tempfailed};
-            }
-            # XXX logically, should clear @{$self->{messages}} here. However
-            # there is something subtle with notattempted() and graylisting.
-            # See comment in Queue code below (search for 'notattempted').
-            # Not sure when that is called though.
-        }
-    }
-    return $self->{state};
-}
-
-#
-# Record events that happen to messages, and update internal counters
-#
-
-# tempfail
-# Record a temporary failure to deliver the current message.
-sub tempfail ($) {
-    my Sender $self = shift;
-    if ($self->{message}) {
-        $self->{message}->owner(undef);
-        $self->{message}->addevent(Queue::Message::EVENT_TEMP_FAILURE,
-                                    $self->{target});
-        $self->{message} = undef;
-        ++$self->{tempfailed};
-    }
-}
-
-# permfail
-# Record a permanent failure to deliver the current message.
-sub permfail ($) {
-    my Sender $self = shift;
-    if ($self->{message}) {
-        $self->{message}->owner(undef);
-        $self->{message}->addevent(Queue::Message::EVENT_PERM_FAILURE,
-                                    $self->{target});
-        $self->{message} = undef;
-        ++$self->{permfailed};
-    }
-}
-
-# delivered
-# Record successful delivery of the current message.
-sub deliver ($) {
-    my Sender $self = shift;
-    if ($self->{message}) {
-        $self->{message}->owner(undef);
-        $self->{message}->addevent(Queue::Message::EVENT_DELIVERED, $self->{target});
-        $self->{message} = undef;
-        ++$self->{delivered};
-    }
-}
-
-
-# activity
-# Update the last-activity timer.
-sub activity ($) {
-    my Sender $self = shift;
-    $self->{lastactivity} = time();
-}
-
-# oops MESSAGE
-# Record the error MESSAGE and put the object into STATE_BAD. This should be
-# used in the case of an error below the SMTP protocol layer, for instance a
-# timeout or an error sending/receiving data.
-sub oops ($$) {
-    my Sender $self = shift;
-    my $text = shift;
-    $self->log('err', $text);
-    $self->{error} = $text . " (while in $statename[$self->state()])";
-    $self->state(STATE_BAD);
-}
-
-# get_smtp_response
-# Parse an SMTP response from the peer, if any is available. On error or if no
-# complete response is available, return (); otherwise return the code and
-# message text (with \r\n replaced by \n).
-sub get_smtp_response ($) {
-    my Sender $self = shift;
-    my $response;
-    my $recvbuf = $self->{recvbuf};
-    # SMTP responses look like:
-    #   "CODE-TEXT\r\n"*
-    #   "CODE TEXT\r\n"
-    # -- but permit the TEXT to be empty. Also permit the last line to be
-    # "CODE\r\n" as recommended by RFC 2821.
-    if ($$recvbuf =~ /^(([2-5][0-5]\d)( .*?|)\r\n)/
-        || $$recvbuf =~ /^(([2-5][0-5]\d)-.*?\r\n(\2-.*?\r\n)*(\2( .*?|)\r\n))/) {
-        # valid single or multiline response
-        my $code = $2;
-        my $message = $1;
-        if ($message =~ /^...-/) {
-            my $rawmsg = "$message";
-            $rawmsg =~ s/\r\n$//s;
-            foreach (split(/\r\n/, $rawmsg)) {
-                $self->log('noise', "<< $_");
-            }
-        } else {
-            my $rawmsg = "$message";
-            $rawmsg =~ s/\r\n$//s;
-            $self->log('noise', "<< $rawmsg");
-        }
-        # Shift the contents of the receive buffer.
-        $$recvbuf = substr($$recvbuf, length($message));
-        # Remove the code from the message.
-        $message =~ s/^($code)[ -]//gm;
-        # Replace the SMTP line endings in the message with UNIX line endings.
-        $message =~ s/\r\n/\n/g;
-        # Record that we have seen a full response.
-        $self->activity();
-        return ($code, $message);
-    } elsif ($recvbuf =~ /^(.+?)\r\n/) {
-        $self->oops("bad SMTP response '$1'");
-        return ();
-    } else {
-        # assume nothing
-        return ();
-    }
-}
-
-# send COMMAND
-# Send COMMAND to the server.
-sub send ($$) {
-    my Sender $self = shift;
-    my $line = shift;
-    ${$self->{sendbuf}} .= "$line\r\n";
-    $self->log('noise', ">> $line");
-}
-
-#
-# SMTP commands
-#
-
-sub ehlo ($) {
-    my Sender $self = shift;
-    # Figure out our name.
-    my $name = mySociety::Config::get('EMAIL_HELO_DOMAIN', undef);
-    if (!defined($name)) {
-        # XXX this could block, but that's probably not a disaster
-        my ($port, $addr) = sockaddr_in(getsockname($self->s()));
-        $name = gethostbyaddr($addr, AF_INET);
-        if (!$name) {
-            $self->log('warning', "unable to get name for local address @{[ inet_ntoa($addr) ]}");
-            $name = sprintf('[%s]', inet_ntoa($addr));
-        }
-    }
-    $self->send("HELO $name");
-    $self->state(STATE_HELO);
-}
-
-sub mail_from ($$) {
-    my Sender $self = shift;
-    my $sender = shift;
-    $self->send("MAIL FROM:<$sender>");
-    $self->state(STATE_MAIL_FROM);
-}
-
-sub rcpt_to ($$) {
-    my Sender $self = shift;
-    my $recipient = shift;
-    $self->send("RCPT TO:<$recipient>");
-    $self->state(STATE_RCPT_TO);
-}
-
-sub data ($) {
-    my Sender $self = shift;
-    $self->send("DATA");
-    $self->state(STATE_DATA);
-}
-
-sub rset ($) {
-    my Sender $self = shift;
-    $self->send("RSET");
-    $self->state(STATE_RSET);
-}
-
-sub quit ($) {
-    my Sender $self = shift;
-    $self->send("QUIT");
-    $self->state(STATE_QUIT);
-}
-
-#
-# Accessors
-#
-
-sub delivered ($) {
-    my Sender $self = shift;
-    return $self->{delivered};
-}
-
-sub tempfailures ($) {
-    my Sender $self = shift;
-    return $self->{tempfailed};
-}
-
-sub permfailures ($) {
-    my Sender $self = shift;
-    return $self->{permfailed};
-}
-
-sub notattempted ($) {
-    my Sender $self = shift;
-    return scalar(@{$self->{messages}});
-}
-
-sub s ($) {
-    my Sender $self = shift;
-    return $self->{s};
-}
-
-sub target ($) {
-    my Sender $self = shift;
-    return $self->{target};
-}
-
-sub id ($) {
-    my Sender $self = shift;
-    return $self->{id};
-}
-
-sub error ($) {
-    my Sender $self = shift;
-    return $self->{error};
-}
-
-# get_message_to_send
-# Obtain the next message to send from the queue, if any. Returns true if a
-# message has been found, or false otherwise (for instance, if we've sent as
-# many messages as we should in this session).
-sub get_message_to_send ($) {
-    my Sender $self = shift;
-    $self->{message} = shift(@{$self->{messages}});
-    if (defined($self->{message})) {
-        $self->log('debug', "processing message ", $self->{message}->id());
-        return 1;
-    } else {
-        $self->log('debug', "no more messages to send");
-        return 0;
-    }
-}
-
-# have_message_to_send
-# Returns true if the next call to get_message_to_send would return true, but
-# does not remove the next message from the queue.
-sub have_message_to_send ($) {
-    my Sender $self = shift;
-    return (@{$self->{messages}} > 0);
-}
-
-# do_reset
-# If there are further messages to send, send RSET and go into STATE_RSET;
-# otherwise, send QUIT and go into STATE_QUIT.
-sub do_reset ($) {
-    my Sender $self = shift;
-    if ($self->have_message_to_send()) {
-        $self->rset();
-    } else {
-        $self->quit();
-    }
-}
-
-# parse_smtp_response CODE TEXT
-# Given an SMTP response with the given CODE and TEXT, push our state machine
-# around.
-sub parse_smtp_response ($$$) {
-    my Sender $self = shift;
-    my ($code, $text) = @_;
-
-    # Make a loggable copy of the response text.
-    my $ltext = "[$code] $text";
-    $ltext =~ s/\n$//s;
-    $ltext =~ s/\n/\\n/gs;
-    
-    # XXX we could probably be a little more lenient with parsing some of the
-    # codes.
-    my $state = $self->state();
-    if ($state == STATE_BANNER) {
-        if ($code =~ /^2/) {
-            # Fine.
-            # QUEUE: note success.
-            $self->ehlo();
-        } else {
-            # Refused. Need to send quit, if we can.
-            # QUEUE: note failure to begin transaction with server.
-            $self->quit();
-        }
-    } elsif ($state == STATE_HELO) {
-        if ($code =~ /^2/) {
-            # Fine.
-            $self->get_message_to_send();
-            $self->mail_from($self->{message}->sender());
-        } else {
-            # Something went wrong.
-            # QUEUE: note failure to begin transaction with server.
-            $self->log('warning', "bad HELO response \"$ltext\"");
-            $self->quit();
-        }
-    } elsif ($state == STATE_MAIL_FROM) {
-        if ($code =~ /^2/) {
-            # Success.
-            $self->rcpt_to($self->{message}->recipient());
-        } elsif ($code =~ /^4/) {
-            # Transient failure. 
-            $self->tempfail();
-            $self->log('warning', "transient failure response after MAIL FROM: \"$ltext\"");
-            $self->do_reset();
-        } elsif ($code =~ /^5/) {
-            # Permanent failure. That's pretty bad since it means that we'd
-            # never be able to deliver a mail to this host from this sender.
-            # So pretend that it's a transient failure instead.
-            $self->tempfail();
-            $self->log('err', "permanent failure response after MAIL FROM: \"$ltext\"");
-            $self->do_reset();
-        } else {
-            # Bad response code.
-            $self->tempfail(); # XXX ?
-            $self->log('err', "bad response after MAIL FROM: \"$ltext\"; abandoning connection");
-            $self->quit();
-        }
-    } elsif ($state == STATE_RCPT_TO) {
-        if ($code =~ /^2/) {
-            # Success.
-            $self->data();
-        } elsif ($code =~ /^4/) {
-            # Transient failure.
-            $self->tempfail();
-            $self->log('warning', "transient failure response after RCPT TO: \"$ltext\"");
-            $self->do_reset();
-        } elsif ($code =~ /^5/) {
-            # Permanent failure. Presumably a bad address.
-            $self->permfail();
-            $self->log('err', "permanent failure response after RCPT TO: \"$ltext\"");
-            $self->do_reset();
-        } else {
-            # Bad response code.
-            $self->tempfail();
-            $self->log('err', "bad response after RCPT TO: \"$ltext\"; abandoning connection");
-            $self->quit();
-        }
-    } elsif ($state == STATE_DATA) {
-        if ($code =~ /^3/) {
-            # Ready to continue. Send the message text.
-            my $msg = $self->{message}->text();
-            my $len = length($msg);
-            $msg =~ s/^\./../gs;
-            $msg =~ s/\n/\r\n/gs;
-            if ($msg =~ /\r\n$/s) {
-                $msg .= ".\r\n";
-            } else {
-                $msg .= "\r\n.\r\n";
-            }
-            $self->log('noise', ">> [ $len bytes of message data ]");
-            $self->{sendbuf} = \$msg;
-            $self->state(STATE_MESSAGE);
-        } else {
-            # Don't know. Give up on this connection.
-            $self->tempfail();
-            $self->log('err', "bad response after DATA: \"$ltext\"; abandoning connection");
-            $self->quit();
-        }
-    } elsif ($state == STATE_MESSAGE) {
-        if ($code =~ /^2/) {
-            # Message has been successfully submitted.
-            $self->log('info', "successful response after message data: \"$ltext\"");
-            $self->deliver();
-            if ($self->get_message_to_send()) {
-                $self->mail_from($self->{message}->sender());
-            } else {
-                $self->quit();
-            }
-        } elsif ($code =~ /^4/) {
-            # Temporary failure.
-            $self->tempfail();
-            $self->log('warning', "transient failure response after message data: \"$ltext\"");
-            $self->do_reset();
-        } elsif ($code =~ /^5/) {
-            # Permanent failure (presumably spam filter or similar).
-            $self->permfail();
-            $self->log('warning', "permanent failure response after message data: \"$ltext\"");
-            $self->do_reset();
-        }
-    } elsif ($state == STATE_QUIT) {
-        $self->state(STATE_EOF);
-    } elsif ($state == STATE_RSET) {
-        if ($self->get_message_to_send()) {
-            $self->mail_from($self->{message}->sender());
-        } else {
-            $self->log('err', "no message to send in STATE_RSET (shouldn't happen)");
-            $self->quit();
-        }
-    }
-}
-
-sub escape_char ($) {
-    if ($_[0] eq "\t") {
-        return '\t';
-    } elsif ($_[0] eq "\n") {
-        return '\n';
-    } elsif ($_[0] eq "\r") {
-        return '\r';
-    } else {
-        return sprintf('\x02x', ord($_[0]));
-    }
-}
-
-# escape_text TEXT
-# Return a copy of TEXT escaped as if for perl or C.
-sub escape_text ($) {
-    my $text = shift;
-    $text =~ s#([\x00-\x1f\x80-\xff])#escape_char($1)#gei;
-    return $text;
-}
-
-# pre_select RDS WRS
-# 
-sub pre_select ($$$) {
-    my Sender $self = shift;
-    my IO::Select $rds = shift;
-    my IO::Select $wrs = shift;
-
-    if ($self->{lastactivity} < time() - TIMEOUT) {
-        if (length(${$self->{recvbuf}})) {
-            $self->oops(sprintf(
-                            'timeout; %d bytes received since last activity',
-                            length(${$self->{recvbuf}})));
-            my $escaped_recvbuf = $self->{recvbuf};
-            $self->log('warning', 'contents of recvbuf at timeout: ' .
-                            escape_text(${$self->{recvbuf}}));
-        } else {
-            $self->oops('timeout');
-        }
-        return;
-    }
-    
-    $rds->add($self->s());
-    # Test for writability if we have data to write, or if we haven't yet
-    # connected (so that we can detect when the connection becomes ready).
-    $wrs->add($self->s()) if (length(${$self->{sendbuf}}) > 0 || $self->state() == STATE_CONNECT);
-}
-
-# post_select RDS WRS
-#
-sub post_select ($$$) {
-    my Sender $self = shift;
-    my ($rds, $wrs) = @_;
-    my $recvbuf = $self->{recvbuf};
-    my $sendbuf = $self->{sendbuf};
-    if (exists($rds->{$self->s()})) {
-        my $n = $self->s()->sysread($$recvbuf, 1024, length($$recvbuf));
-        if (!defined($n) && !$!{EAGAIN}) {
-            # An error occured. This is where we'd see ECONNREFUSED or similar,
-            # too.
-            $self->oops("error receiving data from peer: $!");
-            return;
-        }
-        
-        # Now connected, if we haven't noticed that yet.
-        if ($self->state() == STATE_CONNECT) {
-            $self->log('noise', "now connected (readable)");
-            $self->state(STATE_BANNER);
-        }
-
-        if ($n == 0) {
-            # EOF
-            if ($self->state() != STATE_EOF) {
-                $self->oops("unexpected EOF in connection to peer");
-            } else {
-                $self->state(STATE_DONE);
-            }
-            return;
-        } else {
-            # Read $n bytes of data. See whether we have an SMTP response.
-            if (my ($code, $text) = $self->get_smtp_response()) {
-                $self->parse_smtp_response($code, $text);
-            }
-        }
-    }
-    if (exists($wrs->{$self->s()})) {
-        if ($self->state() == STATE_CONNECT) {
-            # We are now connected.
-            $self->log('noise', "now connected (writable)");
-            $self->state(STATE_BANNER);
-        }
-        
-        if (length($$sendbuf)) {
-            # Data to send.
-            my $o = 0;
-            my $n;
-            while ($o < length($$sendbuf)
-                    && defined($n = $self->s()->syswrite($$sendbuf, length($$sendbuf) - $o, $o))) {
-                $o += $n;
-            }
-            # Typically we will finish writing because we run out of data to
-            # write or because the socket buffer fills, at which point we see
-            # EAGAIN.  However, we may encounter a real transport-layer error.
-            if (!defined($n) && !$!{EAGAIN}) {
-                $self->oops("error sending data to peer: $!");
-                return;
-            } else {
-                # If we didn't transmit the whole buffer, shrink it. Efficiency?
-                # We've heard of it.
-                if ($o == length($$sendbuf)) {
-                    my $s = "";
-                    $$sendbuf = $s;
-                } else {
-                    $$sendbuf = substr($$sendbuf, $o);
-                }
-            }
-        }
-    }
 }
 
 #
@@ -913,11 +221,13 @@ sub post_select ($$$) {
 package Queue;
 
 use Carp;
+use Email::Sender::Simple;
+use Email::Sender::Transport::SMTP;
 use Heap::Priority;
 use IO::Select;
+use Try::Tiny;
 
-use fields qw(messages finished ss lastcheckedqueue
-                noexpire queue);
+use fields qw(messages finished ss lastcheckedqueue noexpire queue);
 
 # How long a message may stay on the queue before we consider it undeliverable.
 use constant MAX_MESSAGE_AGE => 86400;
@@ -945,9 +255,6 @@ sub new ($;$) {
     # list of completed messages
     $self->{finished} = [ ];
     
-    # SMTP clients.
-    $self->{ss} = [ ];
-
     $self->{lastcheckedqueue} = time();
 
     $self->{noexpire} = $noexpire;
@@ -1030,20 +337,13 @@ sub pre_select ($$$) {
     my IO::Select $rds = shift;
     my IO::Select $wrs = shift;
 
-    # Do pre-select handling for individual SMTP clients.
-    foreach my $smtp (@{$self->{ss}}) {
-        $smtp->pre_select($rds, $wrs);
-    }
-
-    # Hash of IP addresses to which to send messages to messages to send to
-    # them.
-    my @newsessions;
-
     # Now see whether we should start any more connections.
     my $now = time();
     return if ($self->{lastcheckedqueue} > $now - 1);
     $self->{lastcheckedqueue} = $now;
     Log::print('noise', "iterating over queue");
+
+    my $transport = Email::Sender::Transport::SMTP->new;
 
     # The queue allows us to find the nominal retry time for the
     # next-most-urgent message, and its identity.
@@ -1072,27 +372,23 @@ Log::print('debug', "  -> too old; failing");
             next;
         }
         
-        # Skip if a sender is already handling this message.
-        if (defined($msg->owner())) {
-Log::print('debug', "  -> already being delivered");
-            next;
-        }
-Log::print('noise', " ... not presently being delivered");
-
-        # OK, we want to send this message.
 Log::print('debug', "  -> will attempt delivery of ", $msg->id());
-        push(@newsessions, $msg);
+
+        try {
+            Email::Sender::Simple->send($msg->{text}, { transport => $transport });
+            $msg->addevent(Queue::Message::EVENT_DELIVERED);
+        } catch {
+            my $error = $_ || 'unknown error';
+            if (try { $error->isa('Email::Sender::Failure::Permanent') }) {
+                $msg->addevent(Queue::Message::EVENT_PERM_FAILURE);
+            } elsif (try { $error->isa('Email::Sender::Failure::Temporary') }) {
+                $msg->addevent(Queue::Message::EVENT_TEMP_FAILURE);
+            } else {
+                die $error;
+            }
+        };
     }
     Log::print('noise', 'finished iterating over queue');
-
-    # Create new session
-    my $host = '127.0.0.1';
-    my $s = new Sender($host, \@newsessions);
-    Log::printf('info', 'created sender S%s for %s to send %d messages',
-                    $s->id(),
-                    $host,
-                    scalar(@newsessions));
-    push(@{$self->{ss}}, $s);
 }
 
 # post_select RDS WRS
@@ -1101,34 +397,12 @@ sub post_select ($$$) {
     my Queue $self = shift;
     my ($rds, $wrs) = @_;
 
-    # Free sender objects which have finished.
-    my @ss;
-    foreach my $smtp (@{$self->{ss}}) {
-        $smtp->post_select($rds, $wrs);
-        my $bad = 0;
-        if ($smtp->state() == Sender::STATE_DONE) {
-            # We don't regard temporary failures as a sign that a host is
-            # "bad", because of the prevalence of (e.g.) greylisting. But
-            # anything which causes us to abandon messages before attempting
-            # delivery does result in the host being marked bad. Maybe review
-            # this decision later.
-            $bad = "some messages went without a delivery attempt in S" . $smtp->id()
-                if ($smtp->notattempted() > 0);
-        } elsif ($smtp->state() == Sender::STATE_BAD) {
-            # Any transport error is regarded as making the host "bad".
-            $bad = "a transport error occured (@{[ $smtp->error() ]}) in S" . $smtp->id();
-        } else {
-            push(@ss, $smtp);
-        }
-    }
-    $self->{ss} = \@ss;
-
     # Record some current state info to the log, and also put it in the process
     # title so it is visible to administrators.
-    Log::printf('noise', 'currently have %d SMTP sessions, %d mails on queue',
-                    scalar(@ss), scalar(keys(%{$self->{messages}})));
-    $0 = sprintf('petemaild (main process; %d SMTP sessions, %d mails on queue)',
-                    scalar(@ss), scalar(keys(%{$self->{messages}})));
+    Log::printf('noise', 'currently have %d mails on queue',
+                    scalar(keys(%{$self->{messages}})));
+    $0 = sprintf('petemaild (main process; %d mails on queue)',
+                    scalar(keys(%{$self->{messages}})));
 }
 
 # get_finished
@@ -1136,12 +410,6 @@ sub post_select ($$$) {
 sub get_finished ($) {
     my Queue $self = shift;
     return shift(@{$self->{finished}});
-}
-
-# accessor
-sub ss ($) {
-    my Queue $self = shift;
-    return $self->{ss};
 }
 
 #
@@ -1747,7 +1015,7 @@ sub database_child_process ($) {
         # ... or any new petitions.
         $st_p->execute($fullscan ? 0 : $max_petition_id);
         while (my $p = $st_p->fetchrow_hashref()) {
-            $id = "p-$p->{id}";
+            my $id = "p-$p->{id}";
             push(@queue,
                     new Source::Packet(
                         Source::Packet::TYPE_NEWMESSAGE,
@@ -1848,35 +1116,6 @@ $SIG{USR2} = sub {
         print FH "\nQueue info:\n";
         print FH "messages count: " . scalar(keys(%{$Q->{messages}})) . "\n";
         print FH "finished count: " . scalar(@{$Q->{finished}}) . "\n";
-        print FH "smtp clients count: " . scalar(@{$Q->{ss}}) . ", they are:\n";
-        my $total_messages_in_smtp = 0;
-        foreach my $smtp_client (@{$Q->{ss}}) {
-            $total_messages_in_smtp ++ if ($smtp_client->{message});
-            $total_messages_in_smtp += scalar(@{$smtp_client->{messages}});
-            print FH "\tS".$smtp_client->id()." target: ".$smtp_client->target();
-            if ($smtp_client->{message}) {
-                print FH " msg: M" . $smtp_client->{message}->id();
-            } else {
-                print FH " msg: none";
-            }
-            print FH " msgs: ";
-            foreach my $one_message (@{$smtp_client->{messages}}) {
-                print FH "M" . $one_message->id() . " ";
-            }
-            print FH "state: " . $smtp_client->{state};
-            print FH " delivered: " . $smtp_client->{delivered};
-            print FH " tempfailed: " . $smtp_client->{tempfailed};
-            print FH " permfailed: " . $smtp_client->{permfailed};
-            print FH " lastactivity: " . $smtp_client->{lastactivity};
-            if ($smtp_client->{error}) {
-                print FH " error: " . $smtp_client->{error};
-            } else {
-                print FH " error: none";
-            }
-            print FH "\n";
-        }
-        print FH "\ttotal messages in SMTP: " . $total_messages_in_smtp . "\n";
-        print FH "smtp clients count: " . scalar(@{$Q->{ss}}) . "\n";
         print FH "lastcheckedqueue: " . $Q->{lastcheckedqueue} . "\n";
         print FH "noexpire: " . $Q->{noexpire} . "\n";
         print FH "queue count: " . $Q->{queue}->count . "\n";
@@ -1887,22 +1126,13 @@ $SIG{USR2} = sub {
         foreach my $message ($Q->{queue}->get_list()) {
             $all_messages{$message->id()} = $message;
         }
-        foreach my $smtp_client (@{$Q->{ss}}) {
-            if ($smtp_client->{message}) {
-                $all_messages{$smtp_client->{message}->id()} = $smtp_client->{message};
-            }
-            foreach my $message (@{$smtp_client->{messages}}) {
-                $all_messages{$message->id()} = $message; 
-            }
-        }
         # XXX should add @finished here, but things don't last there long so doesn't matter much
         # (the finished count being nearly always zero shows that is the case)
         # ... check against main list of messages
         my $found = "";
         my $lost = "";
         foreach my $message (values(%{$Q->{messages}})) {
-            my $message_debug_str = "\tid: M" . $message->id() . " state: " . $message->state() . " owner: " . ($message->owner() ? "S".$message->owner()->id() : "none");
-            $message_debug_str .= " (state: ".$Sender::statename[$message->owner()->{state}]." error: ".$message->owner()->{error}.")" if ($message->owner());
+            my $message_debug_str = "\tid: M" . $message->id() . " state: " . $message->state();
             $message_debug_str .= " queue: " . $message->{queue}. " priority: " . $message->{priority} . " sender: " . $message->sender() . " recipient: " . $message->recipient() . "\n";
             if ($all_messages{$message->id()}) {
                 $found .= $message_debug_str;
@@ -1954,7 +1184,7 @@ petemaild --help | [OPTIONS]
 
 =head1 DESCRIPTION
 
-Fast mail-sending daemon for the petitions site.
+Mail-sending daemon for the petitions site.
 
 =head1 OPTIONS
 

--- a/conf/packages
+++ b/conf/packages
@@ -3,6 +3,7 @@ libfcgi-perl
 libcrypt-blowfish-perl
 libio-string-perl
 php-pear
+libemail-sender-perl
 libmailtools-perl
 libmime-perl | libmime-tools-perl
 libjson-perl


### PR DESCRIPTION
Fixes #42. Does two things - removes the domain resolver, assuming there's a localhost email server. And then removes the email sender, replacing it with Email::Sender. Could do either/or of those if there were some reason we didn't want to do both. The test suite passed on firefly.